### PR TITLE
#07 [feat] MultiplePlainWindows 구현

### DIFF
--- a/WhimsyLand/ContentView.swift
+++ b/WhimsyLand/ContentView.swift
@@ -12,6 +12,14 @@ import RealityKitContent
 struct ContentView: View {
 
     @State private var enlarge = false
+    
+    @State private var showImmersiveSpace = false
+    @State private var immersiveSpaceIsShown = false
+
+    @Environment(\.openImmersiveSpace) var openImmersiveSpace
+    @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
+    
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         RealityView { content in
@@ -32,6 +40,13 @@ struct ContentView: View {
         .toolbar {
             ToolbarItemGroup(placement: .bottomOrnament) {
                 VStack (spacing: 12) {
+                    Button("First View") {
+                        openWindow(id: "first")
+                    }
+                    
+                    Button("Second View") {
+                        openWindow(id: "second")
+                    }
                     Button {
                         enlarge.toggle()
                     } label: {

--- a/WhimsyLand/RealityViews/ChildView.swift
+++ b/WhimsyLand/RealityViews/ChildView.swift
@@ -1,0 +1,72 @@
+//
+//  ChildView.swift
+//  WhimsyLand
+//
+//  Created by KIM, SoonJoo on 7/13/25.
+//
+
+import SwiftUI
+
+struct ChildView: View {
+    var id: String
+    var title: String
+    var color: Color
+// Assets에 image 파일이 없으므로 오류를 피하기 위해 주석 처리. image 파일 추가 후 주석 삭제.
+//    var image: String
+    
+//    @State private var shouldMove = false
+    @State private var position = CGPoint(x: 800, y: 400)
+    @State private var scale = 1.0
+    
+    @Environment(\.dismissWindow) private var dismissWindow
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 20) {
+//            Image(image)
+//                .resizable()
+//                .frame(width: 100, height: 100)
+//                .foregroundColor(.yellow)
+            Text("Hello, \(title)!")
+            Button("Close") {
+                dismissWindow(id: self.id)
+            }
+        }
+        .padding()
+        .frame(width: 200, height: 300, alignment: Alignment.center)
+        .background(color)
+        .position(position)
+        .scaleEffect(CGSize(width: scale, height: scale))
+//        .gesture(
+//            LongPressGesture(minimumDuration: 0.7)
+//                .onEnded { _ in
+//                    print("long press ended")
+//                    shouldMove = true
+//                    withAnimation{
+//                        scale = 1.1
+//                    }
+//                }
+//                .simultaneously(
+//                    with: DragGesture()
+//                        .onChanged { gesture in
+//                            if shouldMove {
+//                                print("drag starts on ", gesture.location)
+//                                position = gesture.location
+//                            } else {
+//                                print("not able to move")
+//                            }
+//                        }
+//                        .onEnded { gesture in
+//                            print("drag endes")
+//                            shouldMove = false
+//                            withAnimation{
+//                                scale = 1.0
+//                            }
+//                        }
+//                )
+//        )
+    }
+}
+
+//#Preview {
+//    ChildView()
+//}

--- a/WhimsyLand/WhimsyLandApp.swift
+++ b/WhimsyLand/WhimsyLandApp.swift
@@ -30,5 +30,21 @@ struct WhimsyLandApp: App {
                 }
         }
         .immersionStyle(selection: .constant(.progressive), in: .progressive)
+        
+        WindowGroup(id: "first") {
+            ChildView(id: "first", title: "first", color: .red)
+            // Assets에 image 파일이 없으므로 오류를 피하기 위해 주석 처리. image 파일 추가 후 주석 삭제.
+
+            //                      , image: "image1")
+        }
+        .windowStyle(.plain)
+        .defaultSize(.infinity)
+
+        WindowGroup(id: "second") {
+            ChildView(id: "second", title: "second", color: .yellow)
+//            , image: "image2")
+        }
+        .windowStyle(.plain)
+        .defaultSize(.infinity)
     }
 }


### PR DESCRIPTION
Multiple Plain Window (글과 그림만 나오는 윈도우)를 구현했습니다.

1. ContentView - 툴바에 openWindow 버튼을 추가했습니다. - First View, Second View
2. Multiple Window 구현을 위해 ChildView.swift 파일을 생성했습니다.
3. WhimsyLandApp에 WindowGroup을 추가했습니다.

<img width="958" height="721" alt="스크린샷 2025-07-13 22 24 39" src="https://github.com/user-attachments/assets/90669e66-b9cd-41e9-a333-cc8a5f6b9719" />

<img width="958" height="721" alt="스크린샷 2025-07-13 22 27 37" src="https://github.com/user-attachments/assets/52dee945-e4ed-4da0-8c5c-4eebd8c3c069" />
<img width="958" height="721" alt="스크린샷 2025-07-13 22 28 23" src="https://github.com/user-attachments/assets/73de6a65-f357-4245-99c0-415ea309bc6a" />
